### PR TITLE
Fix contact page form not sending emails.

### DIFF
--- a/blog/forms.py
+++ b/blog/forms.py
@@ -74,6 +74,45 @@ class CoachingInquiryForm(forms.Form):
             'required': True
         })
     )
+
+class ContactPageInquiryForm(forms.Form):
+    """Form for contact page inquiry submissions"""
+
+    INTEREST_CHOICES = [
+        ('ai', 'AI & Technology'),
+        ('python', 'Python Development'),
+        ('education', 'Educational Technology'),
+        ('productivity', 'Productivity Systems'),
+        ('career', 'Career & Tech Transitions'),
+        ('faith', 'Faith & Intentional Living'),
+        ('other', 'Something Else'),
+    ]
+
+    name = forms.CharField(
+        max_length=100,
+        widget=forms.TextInput(attrs={
+            'class': 'form-input',
+            'placeholder': 'Your name',
+            'required': True
+        })
+    )
+
+    interest = forms.ChoiceField(
+        choices=INTEREST_CHOICES,
+        widget=forms.Select(attrs={
+            'class': 'form-select',
+            'required': True
+        })
+    )
+
+    message = forms.CharField(
+        widget=forms.Textarea(attrs={
+            'class': 'form-textarea',
+            'rows': 4,
+            'placeholder': 'Your message...',
+            'required': True
+        })
+    )
     
     email = forms.EmailField(
         widget=forms.EmailInput(attrs={


### PR DESCRIPTION
- Created a new `ContactPageInquiryForm` with appropriate 'interest' choices.
- Updated the `coaching_inquiry` view to use the correct form (ContactPageInquiryForm or CoachingInquiryForm) based on the referring page.
- Ensured form validation errors are displayed on the correct page (contact or coaching).
- Emails now correctly reflect the source (contact or coaching) and the selected interest's display name.
- Used a setting for the admin email recipient with a fallback.