### PR TITLE
Fix: Remove stray 'main' keyword causing SyntaxError in blog/views.py

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -261,7 +261,6 @@ Sent from Well Scripted Life {form_source} (Referer: {referer})
                 )
                 messages.success(request, 'Thank you! Your message has been sent. I\'ll get back to you soon.')
 
-main
             except Exception as e:
                 messages.error(request, f'There was an error sending your message: {e}. Please try emailing me directly.')
             


### PR DESCRIPTION
This commit removes a stray 'main' keyword found within the `coaching_inquiry` function in `blog/views.py`. This keyword was causing a SyntaxError, which prevented the `blog.views` module from being imported.

The failed import of `blog.views` subsequently caused `blog.urls` to fail to import, leading to a `ModuleNotFoundError` when Django attempted to load the URL configurations during application startup (e.g., during `manage.py migrate` or server start).

Removing this syntax error should allow the application to start correctly.