### PR TITLE
Feat: Reinstate Google Chat notifications for contact/coaching form

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -261,6 +261,22 @@ Sent from Well Scripted Life {form_source} (Referer: {referer})
                 )
                 messages.success(request, 'Thank you! Your message has been sent. I\'ll get back to you soon.')
 
+                # Google Chat Notification Logic
+                if settings.GOOGLE_CHAT_WEBHOOK_URL:
+                    chat_message_payload = {
+                        "text": (
+                            f"New message from {name} ({email}) via {form_source}:\n"
+                            f"*Interest:* {interest_display}\n"
+                            f"*Message:* {message_content}"
+                        )
+                    }
+                    try:
+                        requests.post(settings.GOOGLE_CHAT_WEBHOOK_URL, json=chat_message_payload, timeout=5)
+                    except requests.exceptions.RequestException as chat_e:
+                        # Log the error but don't let it affect the user's experience
+                        # In a production environment, consider using proper logging instead of print
+                        print(f"Error sending Google Chat notification: {chat_e}")
+
             except Exception as e:
                 messages.error(request, f'There was an error sending your message: {e}. Please try emailing me directly.')
             


### PR DESCRIPTION
This commit adds back the logic to send a notification to a configured Google Chat webhook when the contact or coaching inquiry form is successfully submitted.

- The `coaching_inquiry` view in `blog/views.py` now includes a section to post a message to `settings.GOOGLE_CHAT_WEBHOOK_URL` after the confirmation email is sent.
- Error handling is included for the webhook request to prevent it from disrupting the user experience if the webhook fails.

Also provides an analysis that duplicate forms on the contact page are likely due to form HTML embedded in the 'contact' Page object's content in the database, which should be removed via the admin interface.